### PR TITLE
Add container props and additional aria attribute

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -94,6 +94,7 @@ export default class Autosuggest extends Component {
     highlightFirstSuggestion: PropTypes.bool,
     theme: PropTypes.object,
     id: PropTypes.string,
+    containerProps: PropTypes.object, // Arbitrary container props
   };
 
   static defaultProps = {
@@ -105,6 +106,7 @@ export default class Autosuggest extends Component {
     highlightFirstSuggestion: false,
     theme: defaultTheme,
     id: '1',
+    containerProps: {},
   };
 
   constructor({ alwaysRenderSuggestions }) {
@@ -535,6 +537,7 @@ export default class Autosuggest extends Component {
       getSuggestionValue,
       alwaysRenderSuggestions,
       highlightFirstSuggestion,
+      containerProps,
     } = this.props;
     const {
       isFocused,
@@ -787,6 +790,7 @@ export default class Autosuggest extends Component {
         theme={mapToAutowhateverTheme(theme)}
         id={id}
         ref={this.storeAutowhateverRef}
+        containerProps={containerProps}
       />
     );
   }

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -431,7 +431,7 @@ export default class Autowhatever extends Component {
     });
 
     return (
-      <div {...containerProps}>
+      <div aria-controls={itemsContainerId} {...containerProps}>
         {inputComponent}
         {itemsContainer}
       </div>

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -388,7 +388,7 @@ export default class Autowhatever extends Component {
     const containerProps = {
       role: 'combobox',
       'aria-haspopup': 'listbox',
-      'aria-owns': itemsContainerId,
+      'aria-controls': itemsContainerId,
       'aria-expanded': isOpen,
       ...theme(
         `react-autowhatever-${id}-container`,
@@ -431,7 +431,7 @@ export default class Autowhatever extends Component {
     });
 
     return (
-      <div aria-controls={itemsContainerId} {...containerProps}>
+      <div {...containerProps}>
         {inputComponent}
         {itemsContainer}
       </div>


### PR DESCRIPTION
This allows for container props to be passed down to Autowhatever and adds `aria-controls` to the container div as well (was flagged after resolving the `aria-label` issue).

I've tested this using the branch in this PR: https://github.com/Ingenuity-Inc/artlook-client/pull/781 with a local version of this fork (and on this branch) linked.

My plan was to merge this in and then point artlook to this forked version of the module. Is that the right way to go about it?
